### PR TITLE
Supports tilemap compression

### DIFF
--- a/decompress.py
+++ b/decompress.py
@@ -1,8 +1,28 @@
 #!/usr/bin/env python
+import json
 from pathlib import Path
+from typing import BinaryIO
 
 from utils.assets import CompressedAssets
-from utils.decompress import decompress_blocks
+from utils.decompress import decompress_blocks, decompress_tile_map
+
+def dump_assets_catalog(rom: BinaryIO) -> None:
+    assets_catalog_file = Path("./assets_catalog.json")
+    assets_catalog = {}
+    compressed_assets = CompressedAssets()
+
+    for asset_id in range(0, 188):
+        block_count = compressed_assets.get_block_count(rom, asset_id)
+        block_addr = compressed_assets.get_address(rom, asset_id)
+        compression_type = compressed_assets.get_compression_type(rom, asset_id)
+
+        assets_catalog[asset_id] = {"block_count": block_count,
+                                    "block_addr": block_addr.logical_value,
+                                    "compression_type": compression_type}
+
+    assets_catalog_file.write_text(json.dumps(assets_catalog, indent=4))
+
+
 
 if __name__ == "__main__":
     rom_path = Path("bm.sfc")
@@ -19,14 +39,24 @@ if __name__ == "__main__":
         for asset_id in range(0, 188):
             block_count = compressed_assets.get_block_count(rom, asset_id)
             block_addr = compressed_assets.get_address(rom, asset_id)
+            compression_type = compressed_assets.get_compression_type(rom, asset_id)
+
             decompressed_path = decompressed_dir / f"{asset_id:02x}.bin"
-            compressed_path = compressed_dir / "{asset_id:02x}.bin"
+            compressed_path = compressed_dir / f"{asset_id:02x}.bin"
             addr = block_addr.physical
             assert addr is not None
             rom.seek(addr)
-            data = rom.read(block_count * 0x25)
+            data = rom.read(block_count * 0x32)
 
-            decompressed, compressed_size = decompress_blocks(data, block_count)
+            match compression_type:
+                case 0:
+                    decompressed, compressed_size = decompress_blocks(data, block_count)
+                case 1:
+                    decompressed, compressed_size = decompress_tile_map(data, block_count)
+                case _:
+                    print(f"{asset_id:02x}: Unsupported compression_type : {compression_type:02x}")
+                    continue
+
             decompressed_path.write_bytes(decompressed)
-
             compressed_path.write_bytes(data[:compressed_size])
+

--- a/tests/tilemap_compression_test.py
+++ b/tests/tilemap_compression_test.py
@@ -1,0 +1,34 @@
+import unittest
+
+from utils.compress import compress_tile_map
+from utils.decompress import decompress_tile_map
+
+
+class TilemapCompressionTestCase(unittest.TestCase):
+    def test_decompression_empty(self) -> None:
+        data = bytearray(
+            [0x00] * 8
+        )
+
+        decompressed, _ = decompress_tile_map(data, 1)
+        self.assertEqual(len(decompressed), 64)
+
+    def test_decompression_not_empty(self) -> None:
+        data = bytearray(
+            [0x80, 0x12] + ([0] * 7)
+        )
+
+        decompressed, _ = decompress_tile_map(data, 1)
+        self.assertEqual(len(decompressed), 64)
+
+    def test_compression(self) -> None:
+        data = bytearray(
+            [0b11000000, 0x12, 0x13] + ([0] * 7)
+        )
+
+        decompressed, _ = decompress_tile_map(data, 1)
+        self.assertEqual(64, len(decompressed))
+
+        compressed = compress_tile_map(decompressed)
+
+        self.assertEqual(data, compressed)

--- a/utils/assets.py
+++ b/utils/assets.py
@@ -12,6 +12,7 @@ class CompressedAssets:
         self.b1_addr = low_rom_bus.get_address(0x8E82F0)
         self.b2_addr = low_rom_bus.get_address(0x8E83AC)
         self.b3_addr = low_rom_bus.get_address(0x8E8468)
+        self.assets_flags = low_rom_bus.get_address(0x8E8000)
 
     def get_block_count(self, rom: BinaryIO, asset_id: int) -> int:
         addr = (self.block_size_table + asset_id).physical
@@ -19,6 +20,14 @@ class CompressedAssets:
         rom.seek(addr)
         block_count = rom.read(1)
         return ord(block_count)
+
+    def get_compression_type(self, rom: BinaryIO, asset_id: int) -> int:
+        addr = (self.assets_flags + asset_id).physical
+        assert addr is not None
+        rom.seek(addr)
+        flags = rom.read(1)
+
+        return ord(flags) & 0x0f
 
     def get_address(self, rom: BinaryIO, asset_id: int) -> Address:
         addr = (self.b1_addr + asset_id).physical

--- a/utils/compress.py
+++ b/utils/compress.py
@@ -6,7 +6,7 @@ def compress_blocks(data: bytes) -> bytes:
     block_count = len(data) // 32
 
     for current_block in range(block_count):
-        block_data = data[current_block * 32 : (current_block + 1) * 32]
+        block_data = data[current_block * 32: (current_block + 1) * 32]
         compressed_block = compress_block(block_data)
         compressed += compressed_block
     return compressed
@@ -55,3 +55,38 @@ def _compress(data: bytes, k: int, seed: list[int]) -> tuple[int, bytes]:
         xba(seed)
 
     return control_byte, chunk
+
+
+def compress_tile_map(data: bytes) -> bytearray:
+    compressed = bytearray()
+
+    k = 0
+
+    current_b1 = 0
+    current_b2 = 0
+
+    while k < len(data):
+        chunk = bytearray()
+        control_byte = 0
+        i = 0
+        for _ in range(0, 4):
+            b1 = data[k]
+            if b1 != current_b1:
+                control_byte |= 1 << (7 - i)
+                chunk.append(b1)
+                current_b1 = b1
+            k += 1
+            i += 1
+
+            b2 = data[k]
+            if b2 != current_b2:
+                control_byte |= 1 << (7 - i)
+                chunk.append(b2)
+                current_b2 = b2
+            k += 1
+            i += 1
+
+        compressed.append(control_byte)
+        compressed += chunk
+
+    return compressed

--- a/utils/decompress.py
+++ b/utils/decompress.py
@@ -23,3 +23,34 @@ def decompress_blocks(data: bytes, block_count: int) -> tuple[bytearray, int]:
             control_byte = (control_byte << 1) & 0xFF
 
     return decompressed, y
+
+
+def decompress_tile_map(data: bytes, block_count: int) -> tuple[bytearray, int]:
+    decompressed = bytearray()
+
+    y = 0
+    current_b1 = 0
+    current_b2 = 0
+
+    for _ in range(0, block_count):
+        for _ in range(8):
+            control_byte = data[y]
+            y += 1
+            for _ in range(4):
+                if control_byte & 0x80:
+                    current_b1 = data[y]
+                    y += 1
+
+                control_byte = (control_byte << 1 ) & 0xFF
+
+                if control_byte & 0x80:
+                    current_b2 = data[y]
+                    y +=1
+
+                control_byte = (control_byte << 1 ) & 0xFF
+
+
+                decompressed.append(current_b1)
+                decompressed.append(current_b2)
+
+    return decompressed, y


### PR DESCRIPTION
Adds support for compression_type 1.

type 0 is used for tile graphics, type 1 is used for tile maps.

The compression type is stored in a table at `0x8e8000, asset_id` only the lower 4 bits are used for compression type.

```compression_type = *(0x8e80000 + asset_id) & 0x0f```